### PR TITLE
Switched rooms to use demo chats setup

### DIFF
--- a/Sources/DittoChatPackage/Data/DittoService.swift
+++ b/Sources/DittoChatPackage/Data/DittoService.swift
@@ -521,12 +521,7 @@ extension DittoService {
     func createRoom(name: String, isPrivate: Bool) -> DittoDocumentID? {
         let roomId = UUID().uuidString
         let collectionId = isPrivate ? UUID().uuidString : publicRoomsCollectionId
-
-        let messagesId: String = if DittoInstance.dittoShared != nil {
-            UUID().uuidString
-        } else {
-            messagesKey
-        }
+        let messagesId: String = UUID().uuidString
 
         let room = Room(
             id: roomId,


### PR DESCRIPTION
Updated to use chats UUID set up for moss demo and as a way to push forward query based permissions.