### PR TITLE
Make DittoService ditto instance optional to fix retain issue

### DIFF
--- a/Sources/DittoChatCore/Data/DataManager.swift
+++ b/Sources/DittoChatCore/Data/DataManager.swift
@@ -88,7 +88,10 @@ open class DataManager {
     init(ditto: Ditto, usersCollection: String) {
         let localStore: LocalStoreService = LocalStoreService()
         self.localStore = localStore
-        self.p2pStore = DittoService(privateStore: localStore, ditto: ditto, usersCollection: usersCollection, takEnabled: takChatEnabled, chatRetentionPolicy: retentionPolicy)
+        self.p2pStore = ChatCoreDittoService(
+            privateStore: localStore, ditto: ditto, usersCollection: usersCollection, takEnabled: takChatEnabled, 
+            chatRetentionPolicy: retentionPolicy
+        )
         self.publicRoomsPublisher = p2pStore.publicRoomsPublisher.eraseToAnyPublisher()
         self.privateRoomsPublisher = localStore.privateRoomsPublisher
     }

--- a/Sources/DittoChatCore/Data/DataManager.swift
+++ b/Sources/DittoChatCore/Data/DataManager.swift
@@ -73,6 +73,7 @@ protocol ReplicatingDataInterface {
     func allUsersPublisher() -> AnyPublisher<[ChatUser], Never>
 
     func logout()
+    func cleanup()
 }
 
 open class DataManager {
@@ -94,6 +95,10 @@ open class DataManager {
 
     func logout() {
         p2pStore.logout()
+    }
+
+    func cleanup() {
+        p2pStore.cleanup()
     }
 }
 

--- a/Sources/DittoChatCore/Data/DittoService.swift
+++ b/Sources/DittoChatCore/Data/DittoService.swift
@@ -22,7 +22,8 @@ class DittoService: ReplicatingDataInterface {
     private var privateRoomMessagesSubscriptions = [String: DittoSubscription]()
     private var publicRoomMessagesSubscriptions = [String: DittoSubscription]()
 
-    var ditto: Ditto
+    private var _ditto: Ditto?
+    var ditto: Ditto { _ditto! }
     private let usersKey: String
     private var privateStore: LocalDataInterface
     private var chatRetentionPolicy: ChatRetentionPolicy
@@ -30,7 +31,7 @@ class DittoService: ReplicatingDataInterface {
     private var joinRoomQuery: DittoSwift.DittoLiveQuery?
 
     init(privateStore: LocalDataInterface, ditto: Ditto, usersCollection: String, takEnabled: Bool, chatRetentionPolicy: ChatRetentionPolicy) {
-        self.ditto = ditto
+        self._ditto = ditto
         self.privateStore = privateStore
         self.usersKey = usersCollection
         self.usersSubscription = ditto.store[usersCollection].findAll().subscribe()
@@ -92,6 +93,11 @@ class DittoService: ReplicatingDataInterface {
         publicRoomMessagesSubscriptions.forEach { (key: String, value: DittoSubscription) in
             value.cancel()
         }
+    }
+
+    func cleanup() {
+        logout()
+        _ditto = nil
     }
 }
 

--- a/Sources/DittoChatCore/Data/DittoService.swift
+++ b/Sources/DittoChatCore/Data/DittoService.swift
@@ -10,7 +10,7 @@ import Combine
 import DittoSwift
 import SwiftUI
 
-class DittoService: ReplicatingDataInterface {
+class ChatCoreDittoService: ReplicatingDataInterface {
     @Published var publicRoomsPublisher = CurrentValueSubject<[Room], Never>([])
     @Published fileprivate private(set) var allPublicRooms: [Room] = []
     private var allPublicRoomsCancellable: AnyCancellable = AnyCancellable({})
@@ -138,7 +138,7 @@ class DittoService: ReplicatingDataInterface {
 ///  Subscriptions are added at launch for all non-archived public and private rooms via the publishers described above. The
 ///  `addSubscriptions` and `removeSubscriptions`functions are addtionally used by archiving and unarchiving functions,
 ///  as well as joining a private room via QR code.
-extension DittoService {
+extension ChatCoreDittoService {
     // MARK: Subscriptions
 
     func addSubscriptions(for room: Room) {
@@ -186,7 +186,7 @@ extension DittoService {
     }
 }
 
-extension DittoService {
+extension ChatCoreDittoService {
     // MARK: Users
 
     func currentUserPublisher() -> AnyPublisher<ChatUser?, Never> {
@@ -251,7 +251,7 @@ extension DittoService {
 
 // MARK: Messages
 
-extension DittoService {
+extension ChatCoreDittoService {
     func messagePublisher(for msgId: String, in collectionId: String) -> AnyPublisher<Message, Never> {
         return ditto.store.collection(collectionId)
             .findByID(msgId)
@@ -449,7 +449,7 @@ extension DittoService {
     }
 }
 
-extension DittoService {
+extension ChatCoreDittoService {
     // MARK: Rooms
 
     private func updateAllPublicRooms() {
@@ -586,7 +586,7 @@ extension DittoService {
     }
 }
 
-extension DittoService {
+extension ChatCoreDittoService {
     // MARK: Room Archive/Unarchive
 
     func archiveRoom(_ room: Room) {
@@ -727,7 +727,7 @@ extension DittoService {
     }
 }
 
-extension DittoService {
+extension ChatCoreDittoService {
     var peerKeyString: String {
         ditto.presence.graph.localPeer.peerKeyString
     }

--- a/Sources/DittoChatCore/DittoChat.swift
+++ b/Sources/DittoChatCore/DittoChat.swift
@@ -182,4 +182,8 @@ public class DittoChat: DittoSwiftChat {
     public func logout() {
         dataManager.logout()
     }
+    
+    public func cleanup() {
+        dataManager.cleanup()
+    }
 }

--- a/Sources/DittoChatUI/DittoChatUI.swift
+++ b/Sources/DittoChatUI/DittoChatUI.swift
@@ -36,11 +36,15 @@ public class DittoChatUI: DittoChatViews {
         return RoomsListScreen(dataManager: dittoChat.dataManager)
     }
 
+    public func setCurrentUser(withConfig config: UserConfig) {
+        dittoChat.setCurrentUser(withConfig: config)
+    }
+
     public func logout() {
         dittoChat.logout()
     }
-
-    public func setCurrentUser(withConfig config: UserConfig) {
-        dittoChat.setCurrentUser(withConfig: config)
+    
+    public func cleanup() {
+        dittoChat.cleanup()
     }
 }


### PR DESCRIPTION
DittoService strong reference to Ditto instance caused ForgeSwift library crash when reinitializing. This commit fixes the issue by making the ditto instance optional and implementing cleanup.

- DittoService:
    - create new optional private ditto shadow property
    - expose force-unwrapped accessor of shadow property
    - implement cleanup function to set instance to nil
- DataManager:
    - add cleanup function to ReplicatingDataInterface protocol
    - add cleanup pass-through function
- implement cleanup pass-through functions in ChatUI, and ChatCore